### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ The `context` object exposes useful methods to structure your action.
 
 - `context.log(...logs)` allows the user to log messages and make them available on Clay
 - `context.success({ data, textPreview, imagePreview, successType: context.status.SUCCESS_TYPE })` generates a return object indicating a success for the action function
-- `context.fail({ message, errorType: context.status.ERROR_TYPE })` generates a return object indicating a failure of the action function
+- `context.fail({ message, errorType: context.status.ERROR_TYPE, textPreview, imagePreview })` generates a return object indicating a failure of the action function
 
 #### Handling Return Statuses
 The `context` object provides structured statuses. This ensures that the Clay UI shows a proper message for the users of your action.


### PR DESCRIPTION
Indicate how to submit custom textPreview and imagePreview in context.fail object.

**Clubhouse Story**
https://app.clubhouse.io/clay-run/story/3752/display-custom-error-messages-in-cell-preview

### Summary (What)
Add documentation explaining how to add custom error textPreview and imagePreview in action template.

### Motivation (Why)
So that action authors make take advantage of the display of custom error messages.

### Implementation Details (How)
Add the additional `textPreview` and `imagePreview` fields to reference to the `context.fail` object in the documentation of action template.

### Testing
Update all the function parameters to `context.fail({})` references. There is only one in this readme. 
