### PR TITLE
docs: Show examples of using viewOptions in definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,3 +591,43 @@ A quick reference:
     message: 'message here'
   });
 ```
+
+### View Options
+
+Certain UI features for your action can be customized with the `viewOptions` part of the action definition.
+
+- Customizing the "Cards" view of your output data
+- Customizing the button shown in a cell when users select the "On button press" run setting
+
+#### Customizing Cards
+
+As of August 2020, you can customize what appears in the header of each card in the "Cards" through the `viewOptions.cards` object:
+
+```js
+viewOptions: {
+  cards: {
+    header: {
+      title: 'My custom title: {{ path.to.some.attribute }}'
+      image: '{{ path.to.image.url }}'
+    }
+  }
+}
+```
+
+Notice that you can use interpolation within the curly braces `{{ }}`, thanks to Lodash's [`_.template`](https://lodash.com/docs/4.17.15#template) function.
+
+When your output data is an array of objects, the interpolation is applied in the context of each object. When your output data is a top-level object, then the interpolation is applied to that top-level object itself.
+
+#### Customizing Buttons
+
+As of August 2020, you can customize the text shown in the button of a cell in an action column when users choose to run actions "on button press". Example:
+
+```js
+viewOptions: {
+  button: {
+    text: 'Launch rockets!',
+  },
+}
+```
+
+When the button is rendered, it will use this text along with the icon specified by `iconUri` (if it exists).

--- a/src/get_top_reddit_posts/definition.js
+++ b/src/get_top_reddit_posts/definition.js
@@ -40,6 +40,17 @@ const getTopRedditPostsActionDefinition = {
     numberOfPosts: 10
   },
   outputSample: require('./output_sample.js'),
+  //viewOptions: { // optional - customize the way that action views are rendered in Clay
+  //  button: { // optional - customize button when "button press" run setting is applied
+  //    text: 'Launch rockets!', // text to render in action cell button
+  //  },
+  //  cards: { // optional - customize the "cards" view of action output data
+  //    header: { // set a custom header for card
+  //      title: '{{ title }} by @{{ author }}', // header text (uses Lodash template interpolation)
+  //      image: '' // header image URL (also uses Lodash template interpolation)
+  //    }
+  //  }
+  //},
   //pricing: { // INTERNAL ONLY - pricing rules for the action function
   //  requiresPayment: true,
   //  chargedById: "a1b2c3d4",


### PR DESCRIPTION
**DEPENDS ON**: https://github.com/clay-run/clay-base/pull/1189 (wait to merge until this clay-base PR is merged)

**Clubhouse Story**
https://app.clubhouse.io/clay-run/story/3458/update-action-definition-in-action-template-nodejs-with-new-fields

### Summary (What)
Updates README and example definition to describe how to use `viewOptions` to customize cards and buttons.

### Motivation (Why)
To keep this repo up to date with the usage & validation of actions in clay-base.

### Implementation Details (How)
Just adds documentation and some examples.
